### PR TITLE
Fixes for Gen AI course

### DIFF
--- a/04_n_grams.py
+++ b/04_n_grams.py
@@ -3,7 +3,7 @@ from nltk import word_tokenize
 from nltk.util import ngrams
 from collections import Counter
 nltk.download('punkt')
-sample_text = "I am learning NLP( Natural Language Processing)"
+sample_text = "I am learning NLP (Natural Language Processing)"
 tokens = word_tokenize(sample_text)
 
 # Unigram

--- a/05_text_classification.py
+++ b/05_text_classification.py
@@ -12,14 +12,14 @@ labels = [
 ]
 
 vectorizer = CountVectorizer()
-X = vectorizer.fit_transform(texts)
+x = vectorizer.fit_transform(texts)
 
-X_train, X_test, y_train, y_test = train_test_split(X, labels, test_size=0.2, random_state=42)
+x_train, x_test, y_train, y_test = train_test_split(x, labels, test_size=0.2, random_state=42)
 
 model = MultinomialNB()
-model.fit(X_train, y_train)
+model.fit(x_train, y_train)
 
-y_pred = model.predict(X_test)
+y_pred = model.predict(x_test)
 
 accuracy = accuracy_score(y_test, y_pred)
 print("Accuracy:", accuracy)

--- a/08_vibes.py
+++ b/08_vibes.py
@@ -7,7 +7,7 @@ from textblob import TextBlob
 # Sample movie reviews
 reviews = [
     "This movie was fantastic! Amazing, iconic",
-    "I loved it!", "Amazing storyline and great acting!",
+    "I loved it!", "Amazing story line and great acting!",
     "The plot was cringe.",
     "Loved the acting! Highly recommended."
 ]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </div>
 <br>
 
-Welcome to Generative AI GitHub repo! We are super excited to have you. Here, you will find all the solutions to the Codédex challenges. Feel free to make pull requests to add your own twists on the challenges!
+Welcome to the Generative AI GitHub repo! We are super excited to have you. Here, you will find all the solutions to the Codédex challenges. Feel free to make pull requests to add your own twists on the challenges!
 
 ### Website: www.codedex.io/gen-ai
 


### PR DESCRIPTION
Fixes include the following:

- Grammar
- Text classification variable capitalization fixes to match the text and conform to the implied naming convention

In addition, check the following course text issues since I wasn't able to find the course text on this GH user:

- [02 Language Models](https://www.codedex.io/gen-ai/02-language-models) - The result of ``pip install`` shouldn't be "Requirement already satisfied" unless the reader already has it installed in their virtual env.
- [03 Tokenization](https://www.codedex.io/gen-ai/03-tokenization) - The ``nltk.download()`` method should be run in the Python REPL to open the NLTK downloader. I was not able to get this to work in a script as described in the instructions.
- [05 Text Classification](https://www.codedex.io/gen-ai/05-text-classification) - There is a broken Markdown link for the "train_test_split" bullet point.
