### PR TITLE
Fix Label Type Issue in vibes.py

### DIFF
--- a/08_vibes.py
+++ b/08_vibes.py
@@ -3,6 +3,7 @@ from sklearn.naive_bayes import MultinomialNB
 from sklearn.model_selection import train_test_split
 from sklearn.metrics import accuracy_score
 from textblob import TextBlob
+import numpy as np
 
 # Sample movie reviews
 reviews = [
@@ -12,7 +13,7 @@ reviews = [
     "Loved the acting! Highly recommended."
 ]
 # Labels for the reviews
-labels = ["positive", "positive", "positive", "negative", "positive"]
+labels = np.array(["positive", "positive", "positive", "negative", "positive"])
 
 # (Optional) Correct any spelling mistakes in the reviews using TextBlob
 corrected_reviews = [str(TextBlob(review).correct()) for review in reviews]


### PR DESCRIPTION
The labels variable, which contains the sentiment labels for the reviews, was originally a list. However, train_test_split requires the labels to be in an array format for proper splitting. This PR converts the labels list to a NumPy array to ensure compatibility with train_test_split() and avoid any potential errors during model training and testing.